### PR TITLE
fix: Home Link lead to page 2 (old app)

### DIFF
--- a/app/routes/page3.tsx
+++ b/app/routes/page3.tsx
@@ -6,7 +6,7 @@ export default function Page3() {
       <main>
         <p>Page 3 (remix)</p>
 
-        <Link to="/page2">Go home (remix)</Link>
+        <Link to="/">Go home (remix)</Link>
         <br />
         <Link to="/page3">Go to page 3 (remix)</Link>
         <br />


### PR DESCRIPTION
It seemed like page3.tsx (served from new remix app) lead to /page2 (served from old app) when clicking `Go home (remix)`